### PR TITLE
Making DropdownButtonFormField to re-render if parent widget changes

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1562,4 +1562,12 @@ class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
     assert(widget.onChanged != null);
     widget.onChanged(value);
   }
+
+  @override
+  void didUpdateWidget(DropdownButtonFormField<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialValue != widget.initialValue) {
+      setValue(widget.initialValue);
+    }
+  }
 }

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -715,4 +715,49 @@ void main() {
     expect(value, equals('two'));
     expect(dropdownButtonTapCounter, 2); // Should not change.
   });
+
+  testWidgets('DropdownButtonFormField should re-render if value param changes', (WidgetTester tester) async {
+    String currentValue = 'two';
+    final GlobalKey<FormFieldState<String>> key = GlobalKey<FormFieldState<String>>();
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return MaterialApp(
+            home: Material(
+              child: DropdownButtonFormField<String>(
+                key: key,
+                value: currentValue,
+                hint: const Text('Select Value'),
+                decoration: const InputDecoration(
+                    prefixIcon: Icon(Icons.fastfood)
+                ),
+                items: menuItems.map((String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(value),
+                    onTap: () {
+                      setState(() {
+                        currentValue = value;
+                      });
+                    },
+                  );
+                }).toList(),
+                onChanged: (String _) {
+                  // Ignored
+                },
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    expect(currentValue, equals('two'));
+    await tester.tap(find.byType(dropdownButtonType).last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('one').last);
+    await tester.pumpAndSettle();
+    expect(currentValue, equals('one'));
+  });
 }


### PR DESCRIPTION
## Description

I'm just making DropdownButtonFormField to show new value by overrrinding the `didUpdateWidget()` function and replacing the current value with the new widget instance's value.

## Related Issues

https://github.com/flutter/flutter/issues/56898

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A change in behaviour with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage].*

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.